### PR TITLE
Error handling

### DIFF
--- a/exercises/error_handling/errors5.rs
+++ b/exercises/error_handling/errors5.rs
@@ -4,31 +4,30 @@
 // It won't compile right now! Why?
 // Execute `rustlings hint errors5` for hints!
 
-// I AM NOT DONE
-
+use error::Error;
 use std::error;
 use std::fmt;
 use std::num::ParseIntError;
 
-type Result<T, E> = std::result::Result<T, Box<dyn E>>;
+//type Result<T, E> = std::result::Result<T, Box<dyn E>>;
 // TODO: update the return type of `main()` to make this compile.
-fn main() -> Result<(), ParseIntError> {
+fn main() -> Result<(), Box<dyn Error>> {
     let pretend_user_input = "42";
     let x: i64 = pretend_user_input.parse()?;
     println!("output={:?}", PositiveNonzeroInteger::new(x)?);
     Ok(())
 }
 
-// impl From<CreationError> for ParseIntError{
-//     fn from(e: CreationError) -> ParseIntError{
+// impl From<CreationError> for ParseIntError {
+//     fn from(e: CreationError) -> ParseIntError {
 //         return ParseIntError::CreationError(e);
 //     }
 // }
 
-// impl From<ParseIntError> for CreationError{
-// 	fn from(e: ParseIntError) -> CreationError{
-// 		return CreationError::ParseIntError(e);
-// 	}
+// impl From<ParseIntError> for CreationError {
+//     fn from(e: ParseIntError) -> CreationError {
+//         return CreationError::ParseIntError(e);
+//     }
 // }
 // Don't change anything below this line.
 

--- a/exercises/error_handling/errors5.rs
+++ b/exercises/error_handling/errors5.rs
@@ -10,6 +10,7 @@ use std::error;
 use std::fmt;
 use std::num::ParseIntError;
 
+type Result<T, E> = std::result::Result<T, Box<dyn E>>;
 // TODO: update the return type of `main()` to make this compile.
 fn main() -> Result<(), ParseIntError> {
     let pretend_user_input = "42";
@@ -18,6 +19,17 @@ fn main() -> Result<(), ParseIntError> {
     Ok(())
 }
 
+// impl From<CreationError> for ParseIntError{
+//     fn from(e: CreationError) -> ParseIntError{
+//         return ParseIntError::CreationError(e);
+//     }
+// }
+
+// impl From<ParseIntError> for CreationError{
+// 	fn from(e: ParseIntError) -> CreationError{
+// 		return CreationError::ParseIntError(e);
+// 	}
+// }
 // Don't change anything below this line.
 
 #[derive(PartialEq, Debug)]
@@ -34,7 +46,7 @@ impl PositiveNonzeroInteger {
         match value {
             x if x < 0 => Err(CreationError::Negative),
             x if x == 0 => Err(CreationError::Zero),
-            x => Ok(PositiveNonzeroInteger(x as u64))
+            x => Ok(PositiveNonzeroInteger(x as u64)),
         }
     }
 }


### PR DESCRIPTION
Rustlings - gives exercises with minor errors for us to fix and learn.

Originally the error I was getting was

```
the trait `From<CreationError>` is not implemented for `ParseIntError`
```

To fix this I tried:

```
impl From<CreationError> for ParseIntError{
    fn from(e: CreationError) -> ParseIntError{
        return ParseIntError::CreationError(e);
    }
}

impl From<ParseIntError> for CreationError{
	fn from(e: ParseIntError) -> CreationError{
		return CreationError::ParseIntError(e);
	}
}
```

This gave more errors.

Upon further reading, the error was fixed by 
```
fn main() -> Result<(), Box<dyn Error>> {
```

But is there any way by which we can implement the trait `From<CreationError>`  for `ParseIntError` without boxing the error?